### PR TITLE
Fix website crash after whatsapp section edit

### DIFF
--- a/src/components/EspaLuzSection.tsx
+++ b/src/components/EspaLuzSection.tsx
@@ -194,7 +194,7 @@ const EspaLuzSection = () => {
                 Alternative testing environment using Twilio's WhatsApp Sandbox. While our live WhatsApp bot is fully operational, this sandbox provides additional testing capabilities for development purposes.
               </p>
               <Button
-                onClick={openWhatsAppLive}
+                onClick={openLiveWhatsApp}
                 className="w-full bg-gradient-to-r from-emerald-400 via-green-500 to-teal-500 hover:from-emerald-500 hover:via-green-600 hover:to-teal-600 text-white font-semibold py-4 rounded-full transition-all duration-300 shadow-xl ring-2 ring-emerald-300/50"
               >
                 Open WhatsApp Live


### PR DESCRIPTION
Corrected `openWhatsAppLive` to `openLiveWhatsApp` in `EspaLuzSection.tsx` to fix a website crash caused by an undefined function call.

The typo `openWhatsAppLive` was causing a JavaScript error, leading to the entire React application failing to render and displaying a dark screen on the live website.

---
<a href="https://cursor.com/background-agent?bcId=bc-b77a6446-aaf7-45ba-9699-18169f6830e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b77a6446-aaf7-45ba-9699-18169f6830e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

