### PR TITLE
Fix audit order button text wrapping on mobile portfolio

### DIFF
--- a/src/components/InquiryForm.tsx
+++ b/src/components/InquiryForm.tsx
@@ -220,11 +220,14 @@ const InquiryForm = ({ id = "inquiry-form", className }: InquiryFormProps) => {
         <Button
           asChild
           variant="outline"
-          className="w-full border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 hover:text-emerald-200"
+          className="w-full h-auto min-h-10 whitespace-normal py-3 px-4 border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 hover:text-emerald-200"
         >
-          <Link to={auditPayUrl}>
-            <CreditCard className="w-4 h-4 mr-2" />
-            {t("cta.inquiryAuditLink")}
+          <Link
+            to={auditPayUrl}
+            className="flex flex-wrap items-center justify-center gap-2 text-center leading-snug"
+          >
+            <CreditCard className="w-4 h-4 shrink-0" />
+            <span>{t("cta.inquiryAuditLink")}</span>
           </Link>
         </Button>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, the audit payment button on `/portfolio` overflows: the long label text sits outside the button background (EN and ES).

## Fix

Update the audit CTA in `InquiryForm.tsx` to allow text wrapping on narrow screens:

- `whitespace-normal` and `h-auto` on the button (overrides global `whitespace-nowrap`)
- Flex-wrap layout on the inner `Link` so the credit card icon and label stay aligned
- Full-width button with comfortable vertical padding

## Acceptance

- [x] Button is full width on mobile
- [x] Long audit label wraps inside the button (EN + ES)
- [x] Credit card icon stays visible (`shrink-0`)
- [x] Desktop layout unchanged
- [x] `npm run build` passes

**Commit:** `222a2b7`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39c663f-22af-487c-98cd-56c127d5790c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39c663f-22af-487c-98cd-56c127d5790c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

