### PR TITLE
Mission statement rewrite: "What I build" — business services first, trend-grounded personal AI lane

### DIFF
--- a/src/pages/BusinessCard.tsx
+++ b/src/pages/BusinessCard.tsx
@@ -627,7 +627,7 @@ export default function BusinessCard() {
 
                     {/* Mission statement */}
                     <p className="text-center text-[10px] sm:text-xs text-gray-400 mt-6 max-w-md mx-auto leading-relaxed">
-                      One ecosystem, two superpowers. For people: AI companions that walk you through relocation, career reinvention, and personal growth — evolving with you, not just answering you. For business: an agentic AI workforce on duty 24/7 — leads landing in HubSpot CRM while you sleep, a live radar reading the ad market before it saturates, autonomous code review on every push, and bilingual content shipping daily on autopilot.
+                      What I build: WhatsApp & Telegram AI agents that answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM · end-to-end AI automation (Make, n8n, or custom code): trigger → AI → action, documented so you own it · AI search visibility (GEO · AEO · tech SEO) — when someone asks ChatGPT or Perplexity for what you sell, your business is the answer · AI video generation — automated pipelines for product, marketing, and social creative. And for people: companion-grade AI with long-term memory — a bilingual voice tutor in WhatsApp that knows your family, a job-hunt agent that scores and applies while you live your life, a crypto coach built for the post-scam era. The difference: 10 production AI systems running 24/7 — including a bilingual WhatsApp assistant with paying subscribers for 15+ months and a pipeline tracking 300+ opportunities a month in CRM. I ship in days what agencies quote in months.
                     </p>
 
                     {/* Shared engine capabilities — what the whole fleet runs on */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites the Ecosystem Architecture mission statement on the portfolio (`src/pages/BusinessCard.tsx`), per feedback across several iterations:

- **Business lane first**, framed as "What I build:" — WhatsApp & Telegram AI agents (FAQ / lead qualification / booking, bilingual EN/ES, CRM-wired) · end-to-end AI automation (Make, n8n, custom code) · AI search visibility (GEO · AEO · tech SEO) · AI video generation pipelines.
- **Personal lane rebuilt** around what's actually in highest consumer demand right now (AI companions with long-term memory are the fastest-growing paid vertical; agentic task automation ranks top in consumer-appetite surveys): "companion-grade AI with long-term memory — a bilingual voice tutor in WhatsApp that knows your family, a job-hunt agent that scores and applies while you live your life, a crypto coach built for the post-scam era." Each item maps to a real shipped product (EspaLuz, VibeJob, ALGOM). "Personal growth" phrasing removed as generic.
- **Proof close**: 10 production systems 24/7, paying WhatsApp subscribers 15+ months, 300+ opportunities/month in CRM, "I ship in days what agencies quote in months."
- No emojis, copy-only — no layout or styling changes.

## Verification
- ESLint clean on the modified file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

