### PR TITLE
Move "What I build" block above AI Co-Founders; polish personal-AI line

### DIFF
--- a/src/pages/BusinessCard.tsx
+++ b/src/pages/BusinessCard.tsx
@@ -453,6 +453,20 @@ export default function BusinessCard() {
                   </div>
                 </motion.header>
 
+                {/* WHAT I BUILD */}
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.15 }}
+                  className="mb-12"
+                >
+                  <div className="backdrop-blur-xl bg-white/[0.02] rounded-2xl p-6 sm:p-8 border border-white/10">
+                    <p className="text-center text-xs sm:text-sm text-gray-300 max-w-3xl mx-auto leading-relaxed">
+                      What I build: WhatsApp & Telegram AI agents that answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM · end-to-end AI automation (Make, n8n, or custom code): trigger → AI → action, documented so you own it · AI search visibility (GEO · AEO · tech SEO) — when someone asks ChatGPT or Perplexity for what you sell, your business is the answer · AI video generation — automated pipelines for product, marketing, and social creative. Companion-grade personal AI with long-term memory and emotional intelligence — from bilingual WhatsApp tutors that remember your journey, to autonomous job-search agents, to AI coaches built for specialized domains. The difference: 10 production AI systems running 24/7 — including a bilingual WhatsApp assistant with paying subscribers for 15+ months and a pipeline tracking 300+ opportunities a month in CRM. I ship in days what agencies quote in months.
+                    </p>
+                  </div>
+                </motion.div>
+
                 {/* AI CO-FOUNDERS SECTION */}
                 <motion.section 
                   initial={{ opacity: 0 }}
@@ -625,13 +639,8 @@ export default function BusinessCard() {
                       </div>
                     </div>
 
-                    {/* Mission statement */}
-                    <p className="text-center text-[10px] sm:text-xs text-gray-400 mt-6 max-w-md mx-auto leading-relaxed">
-                      What I build: WhatsApp & Telegram AI agents that answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM · end-to-end AI automation (Make, n8n, or custom code): trigger → AI → action, documented so you own it · AI search visibility (GEO · AEO · tech SEO) — when someone asks ChatGPT or Perplexity for what you sell, your business is the answer · AI video generation — automated pipelines for product, marketing, and social creative. And for people: companion-grade AI with long-term memory — a bilingual voice tutor in WhatsApp that knows your family, a job-hunt agent that scores and applies while you live your life, a crypto coach built for the post-scam era. The difference: 10 production AI systems running 24/7 — including a bilingual WhatsApp assistant with paying subscribers for 15+ months and a pipeline tracking 300+ opportunities a month in CRM. I ship in days what agencies quote in months.
-                    </p>
-
                     {/* Shared engine capabilities — what the whole fleet runs on */}
-                    <div className="mt-5 flex flex-wrap justify-center gap-2 max-w-2xl mx-auto">
+                    <div className="mt-6 flex flex-wrap justify-center gap-2 max-w-2xl mx-auto">
                       {[
                         'HubSpot CRM — multi-agent lead pipeline',
                         'Bright Data — live-web research agent',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two changes to the portfolio (`src/pages/BusinessCard.tsx`), per feedback:

1. **Personal-AI line polished** — "And for people:" phrasing removed; now reads: "Companion-grade personal AI with long-term memory and emotional intelligence — from bilingual WhatsApp tutors that remember your journey, to autonomous job-search agents, to AI coaches built for specialized domains."
2. **"What I build" text relocated** — the full mission copy moved out of the Ecosystem Architecture diagram into its own glassmorphic card directly below the header, above the "AI Co-Founders — Autonomous & Live" section, so it's the first thing visitors read. The diagram section keeps its title, hub-spoke layout, capability chips, and proof links — only the paragraph moved (with a slight size bump, `text-xs sm:text-sm`, appropriate for a standalone intro).

## Verification
- ESLint clean; production build passes (sitemap churn from the network-blocked Hashnode fetch reverted).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

