### PR TITLE
"What I build" on both card sides, fully bilingual (EN/ES)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -417,6 +417,7 @@
       "imageAlt": "Article illustration"
     }
   },
+  "whatIBuild": "What I build: WhatsApp & Telegram AI agents that answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM · end-to-end AI automation (Make, n8n, or custom code): trigger → AI → action, documented so you own it · AI search visibility (GEO · AEO · tech SEO) — when someone asks ChatGPT or Perplexity for what you sell, your business is the answer · AI video generation — automated pipelines for product, marketing, and social creative. Companion-grade personal AI with long-term memory and emotional intelligence — from bilingual WhatsApp tutors that remember your journey, to autonomous job-search agents, to AI coaches built for specialized domains. The difference: 10 production AI systems running 24/7 — including a bilingual WhatsApp assistant with paying subscribers for 15+ months and a pipeline tracking 300+ opportunities a month in CRM. I ship in days what agencies quote in months.",
   "section1": {
     "title": "Live AI Products — Monetization Ready",
     "cofounderTitle": "AI Co-Founders — Autonomous & Live",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -417,6 +417,7 @@
       "imageAlt": "Ilustración del artículo"
     }
   },
+  "whatIBuild": "Lo que construyo: agentes de IA para WhatsApp y Telegram que responden preguntas frecuentes, califican leads y agendan citas 24/7 — bilingües EN/ES, conectados a tu CRM · automatización IA de extremo a extremo (Make, n8n o código a medida): disparador → IA → acción, documentada para que sea tuya · visibilidad en búsqueda IA (GEO · AEO · SEO técnico) — cuando alguien le pregunta a ChatGPT o Perplexity por lo que vendes, tu negocio es la respuesta · generación de video con IA — pipelines automatizados para creatividades de producto, marketing y redes. IA personal de nivel compañero con memoria de largo plazo e inteligencia emocional — desde tutores bilingües de WhatsApp que recuerdan tu camino, hasta agentes autónomos de búsqueda de empleo y coaches de IA para dominios especializados. La diferencia: 10 sistemas de IA en producción 24/7 — incluido un asistente bilingüe de WhatsApp con suscriptores de pago desde hace 15+ meses y un pipeline que registra 300+ oportunidades al mes en el CRM. Entrego en días lo que las agencias cotizan en meses.",
   "section1": {
     "title": "Productos IA en Vivo — Listos para Monetización",
     "cofounderTitle": "Co-Fundadores de IA — Autónomos y en Vivo",

--- a/src/pages/BusinessCard.tsx
+++ b/src/pages/BusinessCard.tsx
@@ -462,7 +462,7 @@ export default function BusinessCard() {
                 >
                   <div className="backdrop-blur-xl bg-white/[0.02] rounded-2xl p-6 sm:p-8 border border-white/10">
                     <p className="text-center text-xs sm:text-sm text-gray-300 max-w-3xl mx-auto leading-relaxed">
-                      What I build: WhatsApp & Telegram AI agents that answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM · end-to-end AI automation (Make, n8n, or custom code): trigger → AI → action, documented so you own it · AI search visibility (GEO · AEO · tech SEO) — when someone asks ChatGPT or Perplexity for what you sell, your business is the answer · AI video generation — automated pipelines for product, marketing, and social creative. Companion-grade personal AI with long-term memory and emotional intelligence — from bilingual WhatsApp tutors that remember your journey, to autonomous job-search agents, to AI coaches built for specialized domains. The difference: 10 production AI systems running 24/7 — including a bilingual WhatsApp assistant with paying subscribers for 15+ months and a pipeline tracking 300+ opportunities a month in CRM. I ship in days what agencies quote in months.
+                      {t('whatIBuild')}
                     </p>
                   </div>
                 </motion.div>
@@ -1199,6 +1199,13 @@ export default function BusinessCard() {
                       <div className="text-2xl sm:text-3xl font-bold text-pink-400 mb-1">OCI</div>
                       <div className="text-[10px] sm:text-xs text-gray-400 leading-tight">{t('cardBack.stat3')}</div>
                     </div>
+                  </div>
+
+                  {/* WHAT I BUILD (card back) */}
+                  <div className="mb-8 rounded-2xl bg-white/5 border border-white/10 p-6">
+                    <p className="text-center text-xs sm:text-sm text-gray-300 leading-relaxed">
+                      {t('whatIBuild')}
+                    </p>
                   </div>
 
                   <div className="mb-8" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Per feedback on the portfolio card (`src/pages/BusinessCard.tsx`):

- The "What I build" copy is now an i18n key (`whatIBuild`) in both locale files, with a full Spanish translation ("Lo que construyo: …"), so the ES toggle translates it everywhere it appears.
- **Front side**: the existing block below the header now renders via `t('whatIBuild')` (same placement and styling as before).
- **Back side** (flip side): the same text added in a matching glassmorphic box directly above the "Writing — Articles on AI in production" card.

## Verification
- Both locale JSON files parse; ESLint clean; production build passes (sitemap churn from network-blocked Hashnode fetch reverted).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

