### PR TITLE
Redesign "What I build" — icon service cards, personal-AI highlight, proof chips (EN/ES, both card sides)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -417,7 +417,24 @@
       "imageAlt": "Article illustration"
     }
   },
-  "whatIBuild": "What I build: WhatsApp & Telegram AI agents that answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM · end-to-end AI automation (Make, n8n, or custom code): trigger → AI → action, documented so you own it · AI search visibility (GEO · AEO · tech SEO) — when someone asks ChatGPT or Perplexity for what you sell, your business is the answer · AI video generation — automated pipelines for product, marketing, and social creative. Companion-grade personal AI with long-term memory and emotional intelligence — from bilingual WhatsApp tutors that remember your journey, to autonomous job-search agents, to AI coaches built for specialized domains. The difference: 10 production AI systems running 24/7 — including a bilingual WhatsApp assistant with paying subscribers for 15+ months and a pipeline tracking 300+ opportunities a month in CRM. I ship in days what agencies quote in months.",
+  "whatIBuild": {
+    "eyebrow": "What I build",
+    "item1Title": "WhatsApp & Telegram AI agents",
+    "item1Desc": "Answer FAQs, qualify leads, and book appointments 24/7 — bilingual EN/ES, wired into your CRM.",
+    "item2Title": "End-to-end AI automation",
+    "item2Desc": "Make, n8n, or custom code. One workflow, end to end: trigger → AI → action in your tools — documented so you own it.",
+    "item3Title": "AI search visibility — GEO · AEO · tech SEO",
+    "item3Desc": "When someone asks ChatGPT or Perplexity for what you sell, your business is the answer. Optimized for AI crawlers, answer engines, and LLM retrieval.",
+    "item4Title": "AI video generation",
+    "item4Desc": "End-to-end automated pipelines for product videos, marketing creatives, and social content.",
+    "personalTitle": "Companion-grade personal AI",
+    "personalDesc": "Long-term memory and emotional intelligence — from bilingual WhatsApp tutors that remember your journey, to autonomous job-search agents, to AI coaches built for specialized domains.",
+    "diffLabel": "What makes this different",
+    "diff1": "10 production AI systems running 24/7",
+    "diff2": "Bilingual WhatsApp assistant · paying subscribers 15+ months",
+    "diff3": "300+ opportunities a month tracked in CRM",
+    "punch": "I ship in days what agencies quote in months."
+  },
   "section1": {
     "title": "Live AI Products — Monetization Ready",
     "cofounderTitle": "AI Co-Founders — Autonomous & Live",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -417,7 +417,24 @@
       "imageAlt": "Ilustración del artículo"
     }
   },
-  "whatIBuild": "Lo que construyo: agentes de IA para WhatsApp y Telegram que responden preguntas frecuentes, califican leads y agendan citas 24/7 — bilingües EN/ES, conectados a tu CRM · automatización IA de extremo a extremo (Make, n8n o código a medida): disparador → IA → acción, documentada para que sea tuya · visibilidad en búsqueda IA (GEO · AEO · SEO técnico) — cuando alguien le pregunta a ChatGPT o Perplexity por lo que vendes, tu negocio es la respuesta · generación de video con IA — pipelines automatizados para creatividades de producto, marketing y redes. IA personal de nivel compañero con memoria de largo plazo e inteligencia emocional — desde tutores bilingües de WhatsApp que recuerdan tu camino, hasta agentes autónomos de búsqueda de empleo y coaches de IA para dominios especializados. La diferencia: 10 sistemas de IA en producción 24/7 — incluido un asistente bilingüe de WhatsApp con suscriptores de pago desde hace 15+ meses y un pipeline que registra 300+ oportunidades al mes en el CRM. Entrego en días lo que las agencias cotizan en meses.",
+  "whatIBuild": {
+    "eyebrow": "Lo que construyo",
+    "item1Title": "Agentes de IA para WhatsApp y Telegram",
+    "item1Desc": "Responden preguntas frecuentes, califican leads y agendan citas 24/7 — bilingües EN/ES, conectados a tu CRM.",
+    "item2Title": "Automatización IA de extremo a extremo",
+    "item2Desc": "Make, n8n o código a medida. Un solo flujo, completo: disparador → IA → acción en tus herramientas — documentado para que sea tuyo.",
+    "item3Title": "Visibilidad en búsqueda IA — GEO · AEO · SEO técnico",
+    "item3Desc": "Cuando alguien le pregunta a ChatGPT o Perplexity por lo que vendes, tu negocio es la respuesta. Optimizado para crawlers de IA, motores de respuesta y recuperación LLM.",
+    "item4Title": "Generación de video con IA",
+    "item4Desc": "Pipelines automatizados de extremo a extremo para videos de producto, creatividades de marketing y contenido social.",
+    "personalTitle": "IA personal de nivel compañero",
+    "personalDesc": "Memoria de largo plazo e inteligencia emocional — desde tutores bilingües de WhatsApp que recuerdan tu camino, hasta agentes autónomos de búsqueda de empleo y coaches de IA para dominios especializados.",
+    "diffLabel": "Qué hace esto diferente",
+    "diff1": "10 sistemas de IA en producción 24/7",
+    "diff2": "Asistente bilingüe de WhatsApp · suscriptores de pago 15+ meses",
+    "diff3": "300+ oportunidades al mes registradas en CRM",
+    "punch": "Entrego en días lo que las agencias cotizan en meses."
+  },
   "section1": {
     "title": "Productos IA en Vivo — Listos para Monetización",
     "cofounderTitle": "Co-Fundadores de IA — Autónomos y en Vivo",

--- a/src/pages/BusinessCard.tsx
+++ b/src/pages/BusinessCard.tsx
@@ -57,6 +57,65 @@ interface Particle {
   opacity: number;
 }
 
+function WhatIBuildBlock() {
+  const { t } = useTranslation();
+  const services = [
+    { icon: MessageCircle, titleKey: 'whatIBuild.item1Title', descKey: 'whatIBuild.item1Desc', iconColor: 'text-purple-300', iconBg: 'bg-purple-500/15 border-purple-500/30', cardBg: 'bg-purple-600/10 border-purple-500/25' },
+    { icon: Zap, titleKey: 'whatIBuild.item2Title', descKey: 'whatIBuild.item2Desc', iconColor: 'text-blue-300', iconBg: 'bg-blue-500/15 border-blue-500/30', cardBg: 'bg-blue-600/10 border-blue-500/25' },
+    { icon: Search, titleKey: 'whatIBuild.item3Title', descKey: 'whatIBuild.item3Desc', iconColor: 'text-emerald-300', iconBg: 'bg-emerald-500/15 border-emerald-500/30', cardBg: 'bg-emerald-600/10 border-emerald-500/25' },
+    { icon: Film, titleKey: 'whatIBuild.item4Title', descKey: 'whatIBuild.item4Desc', iconColor: 'text-pink-300', iconBg: 'bg-pink-500/15 border-pink-500/30', cardBg: 'bg-pink-600/10 border-pink-500/25' },
+  ];
+  return (
+    <div className="backdrop-blur-xl bg-white/[0.02] rounded-2xl p-6 sm:p-8 border border-white/10">
+      <div className="text-center mb-6">
+        <p className="text-xs sm:text-sm font-semibold text-purple-300 tracking-wide uppercase">{t('whatIBuild.eyebrow')}</p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+        {services.map((s) => (
+          <motion.div
+            key={s.titleKey}
+            whileHover={{ scale: 1.02 }}
+            className={`p-4 rounded-xl border ${s.cardBg} flex gap-3 transition-all`}
+          >
+            <div className={`w-9 h-9 shrink-0 rounded-lg border ${s.iconBg} flex items-center justify-center`}>
+              <s.icon className={`w-4 h-4 ${s.iconColor}`} strokeWidth={1.75} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-xs sm:text-sm font-bold text-white mb-1 leading-snug">{t(s.titleKey)}</p>
+              <p className="text-[11px] sm:text-xs text-gray-400 leading-relaxed">{t(s.descKey)}</p>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+      <motion.div
+        whileHover={{ scale: 1.01 }}
+        className="mt-3 sm:mt-4 p-4 rounded-xl bg-gradient-to-r from-purple-600/15 to-pink-600/15 border border-purple-400/30 flex gap-3 transition-all"
+      >
+        <div className="w-9 h-9 shrink-0 rounded-lg bg-gradient-to-br from-purple-500/20 to-pink-500/20 border border-purple-400/30 flex items-center justify-center">
+          <Gem className="w-4 h-4 text-purple-200" strokeWidth={1.75} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs sm:text-sm font-bold text-white mb-1 leading-snug">{t('whatIBuild.personalTitle')}</p>
+          <p className="text-[11px] sm:text-xs text-gray-300 leading-relaxed">{t('whatIBuild.personalDesc')}</p>
+        </div>
+      </motion.div>
+      <div className="mt-6">
+        <p className="text-center text-[10px] sm:text-xs font-semibold text-gray-500 uppercase tracking-[0.2em] mb-3">{t('whatIBuild.diffLabel')}</p>
+        <div className="flex flex-wrap justify-center gap-2">
+          {['whatIBuild.diff1', 'whatIBuild.diff2', 'whatIBuild.diff3'].map((k) => (
+            <span key={k} className="text-[9px] sm:text-[10px] px-2.5 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/25 text-emerald-200/90">
+              {t(k)}
+            </span>
+          ))}
+        </div>
+        <p className="mt-4 text-center text-sm sm:text-base font-bold bg-gradient-to-r from-purple-300 via-pink-300 to-purple-300 bg-clip-text text-transparent">
+          {t('whatIBuild.punch')}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export default function BusinessCard() {
   const { t, i18n } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -460,11 +519,7 @@ export default function BusinessCard() {
                   transition={{ delay: 0.15 }}
                   className="mb-12"
                 >
-                  <div className="backdrop-blur-xl bg-white/[0.02] rounded-2xl p-6 sm:p-8 border border-white/10">
-                    <p className="text-center text-xs sm:text-sm text-gray-300 max-w-3xl mx-auto leading-relaxed">
-                      {t('whatIBuild')}
-                    </p>
-                  </div>
+                  <WhatIBuildBlock />
                 </motion.div>
 
                 {/* AI CO-FOUNDERS SECTION */}
@@ -1202,10 +1257,8 @@ export default function BusinessCard() {
                   </div>
 
                   {/* WHAT I BUILD (card back) */}
-                  <div className="mb-8 rounded-2xl bg-white/5 border border-white/10 p-6">
-                    <p className="text-center text-xs sm:text-sm text-gray-300 leading-relaxed">
-                      {t('whatIBuild')}
-                    </p>
+                  <div className="mb-8">
+                    <WhatIBuildBlock />
                   </div>
 
                   <div className="mb-8" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the wall-of-text "What I build" paragraph with a designed block matching the site's existing visual language (`src/pages/BusinessCard.tsx`), rendered by a shared `WhatIBuildBlock` component on both the card front (above AI Co-Founders) and card back (above the Writing card):

- **Four service cards** in a 2-column grid, each with a color-coded glassmorphic icon badge (matching the ecosystem hub palette): WhatsApp & Telegram AI agents (purple, `MessageCircle`) · end-to-end AI automation (blue, `Zap`) · AI search visibility GEO/AEO/tech SEO (emerald, `Search`) · AI video generation (pink, `Film`). Subtle hover scale, same as other cards on the page.
- **Personal-AI highlight card** spanning full width with a purple→pink gradient background and `Gem` icon: "Companion-grade personal AI — long-term memory and emotional intelligence…"
- **"What makes this different"** strip: three emerald proof chips (10 production systems 24/7 · paying subscribers 15+ months · 300+ opportunities/month in CRM) and a gradient-text punchline: "I ship in days what agencies quote in months."
- Copy moved from one long i18n string to structured keys, with full Spanish translations — the ES toggle covers both sides.

No other sections touched; all content remains crawlable text in the DOM (GEO-friendly).

## Verification
- Locale JSONs parse; ESLint clean; production build passes (sitemap churn from network-blocked Hashnode fetch reverted).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f4eb7df-a82a-42a6-b1f2-bc857e07968a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

